### PR TITLE
Added a new debug statement on the test case loading

### DIFF
--- a/java-src/org/webcat/plugins/javatddplugin/ZoltarTest.java
+++ b/java-src/org/webcat/plugins/javatddplugin/ZoltarTest.java
@@ -66,18 +66,18 @@ public class ZoltarTest
             for (File testfile : testList)
             {
                 String testname = testfile.getName();
-
+                log.debug("found "+ testname + "...");
                 if (testname.indexOf("Test") != -1)
                 {
                     //File is a test file
                     int dot = testname.lastIndexOf(".");
                     String name = testname.substring(0, dot);
                     allTestNames.add(name);
-                    log.debug("...."+ testname + " added");
+                    log.debug("....added");
                 }
                 else
                 {
-                    log.debug("...."+ testname + " skipped");
+                    log.debug("....skipped");
                 }
             }
 


### PR DESCRIPTION
This changes the location of the log statement that drops the file name upstream of the method that might drive the out-of-range index. 